### PR TITLE
Store and use environment variables in cf user-provided-service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,9 @@ gem 'httparty'
 # Zendesk
 gem 'zendesk_api'
 
+# Cloudfoundry ruby helper
+gem 'cf-app-utils'
+
 group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '~> 3.0.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,7 @@ GEM
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
+    cf-app-utils (0.6)
     cocoon (1.2.10)
     coderay (1.1.1)
     coffee-rails (4.2.1)
@@ -481,6 +482,7 @@ PLATFORMS
 DEPENDENCIES
   better_errors
   binding_of_caller
+  cf-app-utils
   cocoon
   fog
   govspeak (~> 3.4.0)

--- a/app/services/zendesk_feedback.rb
+++ b/app/services/zendesk_feedback.rb
@@ -1,11 +1,14 @@
 require 'zendesk_api'
+require 'cf-app-utils'
 
 class ZendeskFeedback
   def initialize
+    @credentials = CF::App::Credentials.find_by_service_name('registers-product-site-environment-variables')
+
     @client = ZendeskAPI::Client.new do |config|
-      config.url = ENV['ZENDESK_URL']
-      config.username = ENV['ZENDESK_USERNAME']
-      config.token = ENV['ZENDESK_TOKEN']
+      config.url = @credentials['ZENDESK_URL']
+      config.username = @credentials['ZENDESK_USERNAME']
+      config.token = @credentials['ZENDESK_TOKEN']
     end
   end
 

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,13 +1,16 @@
+require 'cf-app-utils'
+
 CarrierWave.configure do |config|
   if Rails.env.production?
+    @credentials = CF::App::Credentials.find_by_service_name('registers-product-site-environment-variables')
     config.fog_credentials = {
       provider:               'AWS',
-      region:                 'eu-west-2',
-      aws_access_key_id:      Rails.application.secrets.aws_key,
-      aws_secret_access_key:  Rails.application.secrets.aws_secret
+      region:                 @credentials['AWS_REGION'],
+      aws_access_key_id:      @credentials['AWS_KEY'],
+      aws_secret_access_key:  @credentials['AWS_SECRET']
     }
-    config.storage = :fog
-    config.fog_directory  = Rails.application.secrets.aws_bucket
+    config.storage        = :fog
+    config.fog_directory  = @credentials['AWS_BUCKET']
     config.fog_public     = true
     config.fog_attributes = { 'Cache-Control' => 'max-age=315576000' }
   else

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -23,6 +23,3 @@ staging:
 # instead read values from the environment.
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
-  aws_key: <%= ENV["AWS_KEY"] %>
-  aws_secret: <%= ENV["AWS_SECRET"] %>
-  aws_bucket: <%= ENV["AWS_BUCKET"] %>

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,3 +4,8 @@ applications:
   memory: 256MB
   buildpack: ruby_buildpack
   instances: 2
+  services:
+    # postgres database
+    - registers-prod
+    # environment variables (persisted for blue/green deploys)
+    - registers-product-site-environment-variables


### PR DESCRIPTION
This PR is a step towards "zero downtime deploys". 

When an app is cloned it doesn't clone the user provided env variables across so by creating a `user-provided-service` that contains the env variables as credentials in Cloud Foundry and then binding it to the app inside the `manifest.yml` file we always have them available inside the app.

Using the `cf-app-utils` gem allows us access to `VCAP_SERVICES` where we can call the environment variables.