### PR TITLE
Show history link on pipeline page when content present

### DIFF
--- a/app/views/spina/registers/_register.html.haml
+++ b/app/views/spina/registers/_register.html.haml
@@ -16,7 +16,7 @@
       = link_to "View register", register.url, target: :blank
   - else
     %td
-  - if register.phases.present?
+  - if register.history.present?
     %td{class: "links", "data-title" => "View more: "}
       = link_to "View history", register_path(register.slug)
   - else


### PR DESCRIPTION
Previously we wanted to check for “phase history” but we only use the
“history” text field now.